### PR TITLE
Adicionada instrução para obter o comprimento de uma string

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 package-lock.json
+pnpm-lock.yaml
 perguntas.txt

--- a/server/public/javascripts/grammar.js
+++ b/server/public/javascripts/grammar.js
@@ -70,6 +70,7 @@ module.exports = {
          / "return" {return 41} / "allocn" {return 42} / "free" {return 43} 
          / "dupn" {return 44} / "popn" {return 45} / "padd" {return 46} 
          / "nop" {return 65} / "writeln" {return 66} / "and" {return 67} / "or" {return 68}
+         / "strlen" {return 71}
        
        Inst_Int = "pushi" {return 47} / "pushn" {return 48} / "pushg" {return 49} 
          / "pushl" {return 50} / "load" {return 51} / "dup" {return 52} / "pop" {return 53} 

--- a/server/public/javascripts/manual.js
+++ b/server/public/javascripts/manual.js
@@ -30,6 +30,7 @@ var manual = [
         }],
         [ "String Operations" , {
           "CONCAT": "takes n and m, from the pile and stacks the concatenated strings (string ns + string ms) address",
+          "STRLEN": "takes n, from the pile and stacks the size of the string"
         }],
         [ "Heap Operations" , {
           "ALLOC": "integer_n :: allocates a structured block, sized n, and stacks its address",

--- a/server/public/javascripts/vm.js
+++ b/server/public/javascripts/vm.js
@@ -645,6 +645,19 @@ module.exports = {
               } else error = 'Segmentation Fault: or - elements missing'
               break
 
+            case 71: //strlen
+              if (operand_stack.length >= frame_pointer + 1){
+                var n = operand_stack.pop()
+                var ref = this.getRef(n)
+                if (ref[0] === "string") {
+                  var string = string_heap[ref[1]]
+                  operand_stack.push(string.length)
+                }
+                else
+                  error = 'Illegal Operand: strlen - element not String Reference'
+              } else error = 'Segmentation Fault: strlen - elements missing'
+              break
+
             default: 
               error = 'Anomaly: Default case'
           }


### PR DESCRIPTION
Este PR adiciona:

- `strlen`: dá pop de uma string da stack e coloca na mesma o seu comprimento

Nota: este PR é compativel com o #2 e não deve necessitar de alterações.