### PR TITLE
Adicionada instrução para obter qualquer caracter de uma string

### DIFF
--- a/server/public/javascripts/grammar.js
+++ b/server/public/javascripts/grammar.js
@@ -73,6 +73,7 @@ module.exports = {
          / "chrcode" {return 69} 
          / "writechr" {return 70}
          / "strlen" {return 71}
+         / "charat" {return 72}
 
        
        Inst_Int = "pushi" {return 47} / "pushn" {return 48} / "pushg" {return 49} 

--- a/server/public/javascripts/manual.js
+++ b/server/public/javascripts/manual.js
@@ -31,7 +31,8 @@ var manual = [
         [ "String Operations" , {
           "CONCAT": "takes n and m, from the pile and stacks the concatenated strings (string ns + string ms) address",
           "CHRCODE": "takes n from the pile, which must be a string, and stacks the ASCII code from the first character",
-          "STRLEN": "takes n, from the pile and stacks the size of the string"
+          "STRLEN": "takes n, from the pile and stacks the size of the string",
+          "CHARAT": "takes n and m, from the pile and stacks the ASCII code from the character in the string m at the position n"
         }],
         [ "Heap Operations" , {
           "ALLOC": "integer_n :: allocates a structured block, sized n, and stacks its address",

--- a/server/public/javascripts/vm.js
+++ b/server/public/javascripts/vm.js
@@ -681,6 +681,23 @@ module.exports = {
               } else error = 'Segmentation Fault: strlen - elements missing'
               break
 
+              case 72: //charat
+              if (operand_stack.length >= frame_pointer + 2){
+                var n = operand_stack.pop()
+                var m = operand_stack.pop()
+                var ref = this.getRef(m)
+                if (this.isNumber(n) && ref[0] === "string") {
+                  var string = string_heap[ref[1]]
+                  if (string.length > n && n >= 0)
+                    operand_stack.push(string.charCodeAt(n))
+                  else
+                    error = "Segmentation Fault:  - elements missing (string too short)"
+                }
+                else
+                  error = 'Illegal Operand: charat - elements not Number and String Reference'
+              } else error = 'Segmentation Fault:  - elements missing'
+              break
+
             default: 
               error = 'Anomaly: Default case'
           }


### PR DESCRIPTION
Este PR adiciona:

- `charat`: dá pop de um inteiro e de uma string da stack e coloca na mesma o inteiro com a representação ASCII do caracter da string na posição
