### PR TITLE
Stricter instructions in VM

### DIFF
--- a/server/public/javascripts/vm.js
+++ b/server/public/javascripts/vm.js
@@ -22,7 +22,7 @@ module.exports = {
       else return [0]
     },
     putString: function(string_heap, x){
-      string_heap.push(x.substring(0, 30))
+      string_heap.push(x.substring(0, 100))
       return this.toRef("string", string_heap.length-1)
     },
     putStruct: function(struct_heap, x){
@@ -695,7 +695,7 @@ module.exports = {
 
       if (error != ''){
         this.animationError(animation)
-        animation = animation.slice(0, 100)
+        animation = animation.slice(0, 200)
         return [0, error, pointer_code, call_stack, operand_stack, frame_pointer, string_heap, struct_heap, animation]
       }
       return [read, result, pointer_code, call_stack, operand_stack, frame_pointer, string_heap, struct_heap, animation]

--- a/server/public/javascripts/vm.js
+++ b/server/public/javascripts/vm.js
@@ -22,7 +22,7 @@ module.exports = {
       else return [0]
     },
     putString: function(string_heap, x){
-      string_heap.push(x)
+      string_heap.push(x.substring(0, 30))
       return this.toRef("string", string_heap.length-1)
     },
     putStruct: function(struct_heap, x){
@@ -44,7 +44,7 @@ module.exports = {
       var fp_initialized = -1
 
       let nr_instructions = 0
-      var max_instructions = 7000
+      const max_instructions = 1000
 
       // stack input read
       if (input != null){
@@ -695,6 +695,7 @@ module.exports = {
 
       if (error != ''){
         this.animationError(animation)
+        animation = animation.slice(0, 100)
         return [0, error, pointer_code, call_stack, operand_stack, frame_pointer, string_heap, struct_heap, animation]
       }
       return [read, result, pointer_code, call_stack, operand_stack, frame_pointer, string_heap, struct_heap, animation]


### PR DESCRIPTION
Currently running the code:
```
while0:
    pushs "Hello world"
    writes
    jump while0
```
Makes the VM hang for a long time which can lead to be crashed. This is because the number of max instructions is too large and the instruction by instruction execution animation is sent as is as response, and thus the number of "Hello world"s in the HTML grows to megabytes.

This PR aims to mitigate it by making the following changes:
- The number of max instructions is reduced from 7000 to 1000.
- The max string length which can be pushed to the string heap is now ~30~ 100 (previously no limit).
- The animation size is shrinked to ~100~ 200 steps if the max instructions is reached.

Maybe this will still have some holes, but fixing this completely would require the VM code to be run asynchronously or making the VM as a whole faster which is out of scope for this PR. 