### PR TITLE
fix: dupn definition

### DIFF
--- a/server/public/javascripts/manual.js
+++ b/server/public/javascripts/manual.js
@@ -68,7 +68,7 @@ var manual = [
           "LOAD": "integer_n :: takes an address a from the pile and stacks the value found in a[n] in the pile or in the heap (depending on a) ",
           "LOADN": "takes an integer n and an address a from the pile and stacks the value found in a[n] in the pile or in the heap (depending on a) ",
           "DUP": "integer_n :: duplicates and stacks the n values of the top of the pile",
-          "DUPN": "takes the integer n from the pile and duplicates and stacks the n values of the top of the pile",
+          "DUPN": "takes the integer n from the pile and duplicates and stacks n times the value of the top of the pile",
         }],
         [ "Taking from Stack" , {
           "POP": "integer_n :: takes n values from the pile",


### PR DESCRIPTION
A definição anterior da instrução **dupn** poderia induzir a erro sobre a sua função:

**DUPN: takes the integer n from the pile and duplicates and stacks the n values of the top of the pile**

O utilizador pode pensar que um valor *n* é retirado do topo da stack e são duplicados *n* valores do topo da stack, quando na verdade esta instrução age mais como um **dup** onde o seu argumento é o valor do topo da stack.

**NOTA:** Não consigo testar a vm localmente de momento, no entanto acredito que esta mudança não terá impacto suficiente para deixar de funcionar. De qualquer das formas acho correto avisar