### PR TITLE
feat: adicionado instruções copy e copyn

### DIFF
--- a/server/public/javascripts/grammar.js
+++ b/server/public/javascripts/grammar.js
@@ -75,12 +75,13 @@ module.exports = {
          / "strlen" {return 71}
          / "charat" {return 72}
          / "popst" {return 74}
+         / "copyn" {return 75}
 
        
        Inst_Int = "pushi" {return 47} / "pushn" {return 48} / "pushg" {return 49} 
          / "pushl" {return 50} / "load" {return 51} / "dup" {return 52} / "pop" {return 53} 
          / "storel" {return 54} / "storeg" {return 55} / "store" {return 56} / "alloc" {return 57}
-         / "pushst" {return 73}
+         / "pushst" {return 73} / "copy" {return 76}
        
        Comment = "//" [^\\n]*
        

--- a/server/public/javascripts/manual.js
+++ b/server/public/javascripts/manual.js
@@ -67,7 +67,7 @@ var manual = [
           "PUSHST": "integer_n :: pushes the address of the struct heap at index n to the stack",
           "LOAD": "integer_n :: takes an address a from the pile and stacks the value found in a[n] in the pile or in the heap (depending on a) ",
           "LOADN": "takes an integer n and an address a from the pile and stacks the value found in a[n] in the pile or in the heap (depending on a) ",
-          "DUP": "integer_n :: duplicates and stacks the n values of the top of the pile",
+          "DUP": "integer_n :: duplicates and stacks n times the value of the top of the pile",
           "DUPN": "takes the integer n from the pile and duplicates and stacks n times the value of the top of the pile",
           "COPY": "integer_n :: copies the n values of the top of the pile and stacks them in the same order",
           "COPYN": "takes the integer n from the pile and copies and stacks the n values of the top of the pile in the same order",

--- a/server/public/javascripts/manual.js
+++ b/server/public/javascripts/manual.js
@@ -69,6 +69,8 @@ var manual = [
           "LOADN": "takes an integer n and an address a from the pile and stacks the value found in a[n] in the pile or in the heap (depending on a) ",
           "DUP": "integer_n :: duplicates and stacks the n values of the top of the pile",
           "DUPN": "takes the integer n from the pile and duplicates and stacks n times the value of the top of the pile",
+          "COPY": "integer_n :: copies the n values of the top of the pile and stacks them in the same order",
+          "COPYN": "takes the integer n from the pile and copies and stacks the n values of the top of the pile in the same order",
         }],
         [ "Taking from Stack" , {
           "POP": "integer_n :: takes n values from the pile",

--- a/server/public/javascripts/vm.js
+++ b/server/public/javascripts/vm.js
@@ -724,8 +724,8 @@ module.exports = {
                     values.push(v)
                   }
                   values = [...values, ...values]
-                  for (const v of values)
-                    operand_stack.push(v)
+                  for (var i = values.length - 1; i >= 0; i--)
+                    operand_stack.push(values[i])
                 } else error = 'Segmentation Fault: copyn - elements missing'
               } else error = 'Segmentation Fault: copyn - elements missing'
               break
@@ -738,8 +738,8 @@ module.exports = {
                   values.push(v)
                 }
                 values = [...values, ...values]
-                for (const v of values)
-                  operand_stack.push(v)
+                for (var i = values.length - 1; i >= 0; i--)
+                  operand_stack.push(values[i])
               } else error = 'Segmentation Fault: copy - elements missing'
               break
 

--- a/server/public/javascripts/vm.js
+++ b/server/public/javascripts/vm.js
@@ -714,7 +714,36 @@ module.exports = {
                 error = 'Segmentation Fault: popst - elements missing'
               break
 
+            case 75: // copyn
+              if (operand_stack.length >= frame_pointer + 1){
+                var n = operand_stack.pop()
+                if (operand_stack.length >= frame_pointer + n){
+                  var values = []
+                  for (let i=0; i < n; i++){
+                    var v = operand_stack.pop()
+                    values.push(v)
+                  }
+                  values = [...values, ...values]
+                  for (const v of values)
+                    operand_stack.push(v)
+                } else error = 'Segmentation Fault: copyn - elements missing'
+              } else error = 'Segmentation Fault: copyn - elements missing'
+              break
 
+            case 76: // copy
+              var values = []
+              if (operand_stack.length >= frame_pointer + c[2]){
+                for (let i=0; i < c[2]; i++){
+                  var v = operand_stack.pop()
+                  values.push(v)
+                }
+                values = [...values, ...values]
+                for (const v of values)
+                  operand_stack.push(v)
+              } else error = 'Segmentation Fault: copy - elements missing'
+              break
+
+            
             default: 
               error = 'Anomaly: Default case'
           }


### PR DESCRIPTION
Em virtude do meu [PR anterior](https://github.com/jcramalho/EWVM/pull/12) onde corrigi a definição de uma das instruções já existentes, decidi implementar uma nova, que faz o que a definição que corrigi anteriormente sugeria:

* `copy integer_n`: duplica os n elementos do topo da stack por ordem.
* `copyn`: retira um elemento n do topo da stack e duplica os n elementos do topo da stack por ordem.

Decidi escolher o nome `copy` e `copyn` porque embora também se comportem como instruções de duplicação, achei que se tornaria menos ambíguo pois já existem instruções com nome `dup` e `dupn`. No entanto, sugestões para melhor nomenclatura são bem vindas e encorajadas.

**Apenas foi adicionado código, portanto não altera o anterior comportamento da VM**