### PR TITLE
Fix ALLOCN instruction

### DIFF
--- a/server/public/javascripts/vm.js
+++ b/server/public/javascripts/vm.js
@@ -439,7 +439,7 @@ module.exports = {
                 var n = operand_stack.pop()
                 var struct = []
                 struct.length = n
-                operand_stack.push( this.putStruct(struct_heap, h) )
+                operand_stack.push( this.putStruct(struct_heap, struct) )
               } else error = 'Segmentation Fault: allocn - elements missing'
               break
             case 43: //free                                                 // heap


### PR DESCRIPTION
Previously, the code below would result in an error (`Anomaly: ReferenceError: h is not defined`). Now it works as expected.

```
START:
  PUSHI 10
  ALLOCN
```

@jcramalho I was wondering if it would be a good idea to limit to how much memory can be allocated. Right now, it's very easy, either with the `ALLOC` or the `ALLOCN` instruction, to attack the server with a denial of service.