### PR TITLE
Fix CHECK and PUSHA instructions / Added multi-user support.

### DIFF
--- a/server/editor/index.js
+++ b/server/editor/index.js
@@ -195,6 +195,7 @@ const highlighter = editor.createDecorationsCollection();
 editor.getModel().onDidChangeContent((e) => {
     let src = editor.getValue();
     document.getElementById('code').value = src;
+    document.getElementById('input_code').value = src;
 });
 
 // Debug highlight

--- a/server/public/javascripts/grammar.js
+++ b/server/public/javascripts/grammar.js
@@ -47,7 +47,7 @@ module.exports = {
          / "pushf" _ info:Float							{ codigos.push([lines, 58, info]) }
          / "pushs" _ info:String        				{ codigos.push([lines, 59, info]) }
          / "err" _ info:String        					{ codigos.push([lines, 60, info]) }
-         / "check" _ info:(Integer _ "," _ Integer)   	{ codigos.push([lines, 61, info[0], info[1]]) }
+         / "check" _ info:(Integer _ "," _ Integer)   	{ codigos.push([lines, 61, info[0], info[4]]) }
          / "jump" _ info:Label 							{ labelsUsed.push(info); codigos.push([lines, 62, info]) }
          / "jz" _ info:Label 							{ labelsUsed.push(info); codigos.push([lines, 63, info]) }
          / "pusha" _ info:Label 						{ labelsUsed.push(info); codigos.push([lines, 64, info]) }

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -145,8 +145,6 @@ router.get('/run', function(req, res, next) {
 });
 
 router.post('/run', function(req, res) {
-  // console.log("RUN:", req.body);
-
   const sessionId = req.body.sessionId ?? makeId(64);
   /** @type {SessionData} */
   let sessionData, ressurected = false;
@@ -155,13 +153,11 @@ router.post('/run', function(req, res) {
     sessionStorage.add(sessionId, _sessionData);
 
     sessionData = _sessionData;
-    // console.log("NEW SESSION DATA", sessionId);
   } else {
     sessionData = sessionStorage.get(req.body.sessionId);
     ressurected = true;
   }
 
-  // console.log("SESSION DATA:", sessionData);
   // Supposedly, req.file could also be handled here, but I haven't looked at the file processing leftovers yet.
   // if (req.body.code !== undefined && (!req.body.input || (req.body.input && !ressurected))) {
   if (req.body.code !== undefined && (!req.body.input || !ressurected)) {
@@ -188,7 +184,6 @@ router.post('/run', function(req, res) {
     sessionData.run();
   }
 
-  // console.log("OUT:", sessionData.out());
   return res.render("index", sessionData.out());
 });
 

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -85,7 +85,10 @@ router.post('/run', function(req, res, next) {
   }
 
   // Grammar Error
-  if (!Array.isArray(code_stack)) result = code_stack
+  if (!Array.isArray(code_stack)) {
+    result = [code_stack]
+    animation = ["error"]
+  }
   // Assembly Code done
   else if (result == null) 
     try{ 

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,49 +1,134 @@
 /* -- Metadados de controlo -- */
-var metadados = {version: "1.3", vdate: "2024-05-02"}
+const metadados = { version: "1.3", vdate: "2024-05-02" }
 /* -- Metadados de controlo -- */
 
-var express = require('express');
-var router = express.Router();
-var peggy = require("peggy");
+const express = require('express');
+const router = express.Router();
+const peggy = require("peggy");
 const fs = require('fs');
 const path = require('path');
 
 const grammar = require('../public/javascripts/grammar.js');
 const { manual } = require('../public/javascripts/manual.js');
 const vm = require('../public/javascripts/vm.js');
-var counter_path = '../instruction_counter.json'
-const counter_file = require(counter_path);
 const catalogo = require('../catalogo.json');
+const EphemeralStorage = require('../util/EphemeralStorage.js');
+const makeId = require('../util/makeId.js');
 
-var parser = peggy.generate(grammar.grammar())
+const parser = peggy.generate(grammar.grammar());
 
-var pointer_code = 0
-var call_stack = []
-var operand_stack = []
-var frame_pointer = 0
-var code_stack = []
-var string_heap = []
-var struct_heap = []
-var code
-var animation
-
-Components = {
-  change: function(pc, call_s, operand_s, fp, string_h, struct_h, a){
-    pointer_code = pc
-    call_stack = call_s
-    operand_stack = operand_s
-    frame_pointer = fp
-    string_heap = string_h
-    struct_heap = struct_h
-    animation = a
+const sessionStorage = new EphemeralStorage({
+  autoPrune: {
+    // interval: 15 * 60000 // 15m
+    interval: 500
   },
+  ttl: 15 * 60000 // 15m
+  // ttl: 1000
+});
+
+class SessionData {
+  constructor(sessionId) {
+    this.sessionId = sessionId;
+    this.reset();
+  }
+
+  reset() {
+    this.pointer_code = 0;
+    this.call_stack = [];
+    this.operand_stack = [];
+    this.frame_pointer = 0;
+    this.code_stack = [];
+    this.string_heap = [];
+    this.struct_heap = [];
+    this.code = "";
+    this.animation = [];
+
+    this.result = undefined;
+    this.index = 0;
+    this.input = 0;
+    this.terminal = [];
+  }
+
+  loadCode(code) {
+    this.code = code;
+
+    const preparedCode = grammar.lowerGrammar(code)
+    try {
+      this.code_stack = parser.parse(preparedCode)
+      return true;
+    } catch (error) {
+      this.result = [`GRAMMAR - ${error}`];
+      this.animation = ["error"];
+      return false;
+    }
+  }
+
+  run(input = null) {
+    try {
+      const results = vm.run(
+        input, 
+        this.code_stack, 
+        this.pointer_code, 
+        this.call_stack, 
+        this.operand_stack, 
+        this.frame_pointer, 
+        this.string_heap, 
+        this.struct_heap, 
+        this.animation, 
+        this.terminal.length - 1
+      ); 
+
+      this.input = results[0];
+      if (Array.isArray(results[1])) this.result = this.terminal.concat(results[1])  // keep terminal info + new results
+      else this.result = [results[1]]    // result is an error
+
+      this.pointer_code = results[2];
+      this.call_stack = results[3];
+      this.operand_stack = results[4];
+      this.frame_pointer = results[5];
+      this.string_heap = results[6];
+      this.struct_heap = results[7];
+      this.animation = results[8];
+    } catch(e) {
+      this.result = [`Anomaly: ${e?.message ?? e ?? "Unknown"}`];
+      this.animation = ["error"];
+    }
+  }
+
+  out() {
+    return { 
+      title: 'EWVM', 
+      code: this.code, 
+      terminal: this.result, 
+      input: this.input, 
+      animation: JSON.stringify(this.animation), 
+      index: this.index, 
+      metadados: metadados, 
+      sessionId: this.sessionId
+    };
+  }
+
+  error(result) {
+    this.animation = ["error"];
+    this.result = [result];
+
+    return this.out();
+  }
 }
 
 /* GET home page. */
 router.get('/', function(req, res, next) {
-  res.render('index', { title: 'EWVM', code: '', terminal: [], input:0, animation:[], index:0, metadados: metadados});
-  // clean components
-  Components.change(0, [], [], 0, [], [], [])
+  const sessionId = req.query._q ?? makeId(64);
+  res.render('index', { 
+    title: 'EWVM', 
+    code: '', 
+    terminal: [], 
+    input: 0, 
+    animation: [], 
+    index: 0, 
+    metadados: metadados, 
+    sessionId: sessionId 
+  });
 });
 
 router.get('/manual', function(req, res) {
@@ -55,64 +140,56 @@ router.get('/credits', function(req, res) {
 })
 
 router.get('/run', function(req, res, next) {
-  res.redirect('/')
+  const sessionId = req.query._q;
+  res.redirect(`/${sessionId !== undefined ? `?_q=${sessionId}` : ""}`);
 });
 
+router.post('/run', function(req, res) {
+  // console.log("RUN:", req.body);
 
-router.post('/run', function(req, res, next) {
-  var result = null
-  var read = 0
-  var input = null
-  var index = 0
-  var terminal = []
+  const sessionId = req.body.sessionId ?? makeId(64);
+  /** @type {SessionData} */
+  let sessionData, ressurected = false;
+  if (!sessionStorage.has(sessionId)) {
+    const _sessionData = new SessionData(sessionId);
+    sessionStorage.add(sessionId, _sessionData);
 
-  // New code submitted
-  if (req.file != undefined || req.body.code != undefined){
-    // new program, clean components
-    Components.change(0, [], [], 0, [], [], [])
-
-    // Written code submitted
-    if (req.body.code != undefined) code = req.body.code
-
-    // Run Assembler
-    var prepared_code = grammar.lowerGrammar(code)
-    try{
-      code_stack = parser.parse(prepared_code)
-    } catch (error) { // Grammar Error
-      result = ["GRAMMAR - ".concat(error)]
-      animation = ["error"]
-    }
+    sessionData = _sessionData;
+    // console.log("NEW SESSION DATA", sessionId);
+  } else {
+    sessionData = sessionStorage.get(req.body.sessionId);
+    ressurected = true;
   }
 
-  // Grammar Error
-  if (!Array.isArray(code_stack)) {
-    result = [code_stack]
-    animation = ["error"]
-  }
-  // Assembly Code done
-  else if (result == null) 
-    try{ 
-      // input submitted
-      if (req.body.input != undefined){
-        input = req.body.input
-        index = req.body.index
-        terminal = req.body.terminal.replace(/\\n/g,'\n').split('"')
-      }
-      // run vm
-      results = vm.run(input, code_stack, pointer_code, call_stack, operand_stack, frame_pointer, string_heap, struct_heap, animation, terminal.length - 1) 
+  // console.log("SESSION DATA:", sessionData);
+  // Supposedly, req.file could also be handled here, but I haven't looked at the file processing leftovers yet.
+  // if (req.body.code !== undefined && (!req.body.input || (req.body.input && !ressurected))) {
+  if (req.body.code !== undefined && (!req.body.input || !ressurected)) {
+    sessionData.reset();
 
-      read = results[0]
-      if (Array.isArray(results[1])) result = terminal.concat(results[1])  // keep terminal info + new results
-      else result = [results[1]]    // result is an error
-
-      Components.change(results[2], results[3], results[4], results[5], results[6], results[7], results[8])
-
-    } catch(error){ 
-      result = ["Anomaly: ".concat(error)]
-      animation = ["error"]
+    let lCodeRes;
+    lCodeRes = sessionData.loadCode(req.body.code);
+    if (lCodeRes !== true) {
+      return res.render("index", sessionData.out());
     }
-  // render page
-  res.render('index', { title: 'EWVM', code: code, terminal: result, input: read, animation:JSON.stringify(animation), index:index, metadados: metadados });
+
+    // Grammar error
+    if (!Array.isArray(sessionData.code_stack)) {
+      return res.render("index", sessionData.error(sessionData.code_stack));
+    }
+  }
+  
+  // Process input. If it wasn't ressurected, start from 0.
+  if (req.body.input != undefined && ressurected) {
+    sessionData.index = req.body.index;
+    sessionData.terminal = req.body.terminal.replace(/\\n/g,'\n').split('"');
+    sessionData.run(req.body.input);
+  } else {
+    sessionData.run();
+  }
+
+  // console.log("OUT:", sessionData.out());
+  return res.render("index", sessionData.out());
 });
 
 router.get('/examples', function(req, res, next) {

--- a/server/util/EphemeralStorage.js
+++ b/server/util/EphemeralStorage.js
@@ -1,0 +1,149 @@
+/**
+ * @typedef {Object} StorageEntry
+ * @prop {number} addedAt The Unix Timestamp of the time when this entry was added to storage.
+ * @prop {number} expire The time (in milliseconds) that this entry is valid for since {@link StorageEntry.addedAt}.
+ * @prop {unknown} value The value stored by this entry.
+ */
+
+const deepMerge = require("./object");
+
+/**
+ * @typedef {Object} _ESOAutoPrune
+ * @prop {number} interval The interval, in milliseconds, for the prune to occur.
+ */
+
+/**
+ * @typedef {_ESOAutoPrune | false} ESOAutoPrune
+ */
+
+/**
+ * @typedef {Object} EphemeralStorageOptions
+ * @prop {ESOAutoPrune} autoPrune Controls whether the system should prune expired entries on a given interval.
+ * @prop {boolean} pruneDeadOnAccess Whether the system should prune expired entries on every access to any property
+ * @prop {boolean} refreshOnAccess Whether the system should refresh the expiration date on an entry when accessing it.
+ * @prop {number} ttl The default Time-To-Live for any new entry, if not overriden.
+ */
+
+/**
+ * @type {EphemeralStorageOptions}
+ */
+const DEFAULTS = { 
+    autoPrune: {
+        interval: 1000
+    },
+    pruneDeadOnAccess: false,
+    refreshOnAccess: true,
+    ttl: 1000
+};
+
+/**
+ * Ephemeral Storage is a storage class that regularly prunes entries based on their expiration intervals
+ */
+class EphemeralStorage {
+    /**
+     * @param {Partial<EphemeralStorageOptions>} options 
+     */
+    constructor(options = DEFAULTS) {
+        /** @type {EphemeralStorageOptions} */
+        this._options = deepMerge(DEFAULTS, options);
+        if (this._options.autoPrune) this._pruneTimer = setInterval(this._prune.bind(this), this._options.autoPrune.interval);
+
+        /** @type {Map<string, StorageEntry>} */
+        this.storage = new Map();
+    }
+
+    /**
+     * Removes expired entries from the storage. Called by either the autoprunning timer, or entry accessors.
+     */
+    _prune() {
+        // console.log("ES AUTOPRUNE")
+        for (const [k, v] of this.storage) {
+            if (v.addedAt + v.expire <= Date.now()) {
+                // console.log(`PRUNNED:`, k, v)
+                this.storage.delete(k);
+            }
+        }
+    }
+
+    /**
+     * Determines whether a given key has an entry associated with it in storage.
+     * @param {string} key The key for the query.
+     * @returns {boolean}
+     */
+    has(key) {
+        if (this._options.refreshOnAccess) this.refresh(key);
+        if (this._options.pruneDeadOnAccess) this._prune();
+        return this.storage.has(key);
+    }
+
+    /**
+     * Fetches the value assossicated with the given key from storage, or undefined if it doesn't exist.
+     *
+     * @param {string} key The key for the query.
+     * @returns {unknown}
+     */
+    get(key) {
+        if (!this.storage.has(key)) return undefined;
+
+        if (this._options.refreshOnAccess) this.refresh(key);
+        if (this._options.pruneDeadOnAccess) this._prune();
+        return this.storage.get(key).value;
+    }
+
+    /**
+     * Stores a given value, optionally with a Time To Live, in milliseconds.
+     * 
+     * @param {string} key The entry key to be assossiated with the value.
+     * @param {unknown} value The value to store.
+     * @param {number=} ttl The Time To Live for this value in storage.
+     * @returns {boolean} `true`, if the key didn't already exist, `false` otherwise.
+     */
+    add(key, value, ttl = this._options.ttl) {
+        if (this._options.pruneDeadOnAccess) this._prune();
+        if (this.storage.has(key)) return false;
+
+        this.storage.set(key, {
+            addedAt: Date.now(),
+            expire: ttl,
+            value: value
+        });
+        return true;
+    }
+
+    /**
+     * Modifies a given stored value associated with a given key.
+     * If no entry exists with the given key, a new entry will be created.
+     * 
+     * @param {string} key The key associated with the target entry.
+     * @param {unknown} value The new value to store on the entry.
+     */
+    set(key, value) {
+        if (this.storage.has(key)) {
+            this.storage.get(key).value = value;
+            if (this._options.refreshOnAccess) this.refresh(key);
+        } else {
+            this.add(key, value);
+        }
+
+        if (this._options.pruneDeadOnAccess) this._prune();
+    }
+
+    /**
+     * 
+     * @param {string} key The key associated with the target entry.
+     * @param {number=} ttl The new Time To Live for the entry. If omitted, the original TTL will be preserved.
+     * @returns {boolean} `true`, if the entry existed, `false` otherwise.
+     */
+    refresh(key, ttl = undefined) {
+        if (this._options.pruneDeadOnAccess) this._prune();
+        if (!this.storage.has(key)) return false;
+
+        const entry = this.storage.get(key);
+        entry.addedAt = Date.now();
+        if (ttl) entry.ttl = ttl;
+        
+        return true;
+    }
+}
+
+module.exports = EphemeralStorage;

--- a/server/util/EphemeralStorage.js
+++ b/server/util/EphemeralStorage.js
@@ -56,10 +56,8 @@ class EphemeralStorage {
      * Removes expired entries from the storage. Called by either the autoprunning timer, or entry accessors.
      */
     _prune() {
-        // console.log("ES AUTOPRUNE")
         for (const [k, v] of this.storage) {
             if (v.addedAt + v.expire <= Date.now()) {
-                // console.log(`PRUNNED:`, k, v)
                 this.storage.delete(k);
             }
         }

--- a/server/util/makeId.js
+++ b/server/util/makeId.js
@@ -1,0 +1,12 @@
+const possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+function makeId(length) {
+    let text = "";
+
+    for(let i = 0; i < length; i++) {
+        text += possible.charAt(Math.floor(Math.random() * possible.length));
+    }
+
+    return text;
+}
+
+module.exports = makeId;

--- a/server/util/object.js
+++ b/server/util/object.js
@@ -1,0 +1,35 @@
+function deepMerge(objA, objB) {
+    if (typeof objA !== "object" || typeof objB !== "object") throw new TypeError("Cannot merge non-objects.");
+
+    if (Array.isArray(objA) && Array.isArray(objB)) {
+        return [...objA, ...objB];
+    } else if (Array.isArray(objA) || Array.isArray(objB)) {
+        throw new TypeError("Cannot merge array with non-array.");
+    } else {
+        const nObj = {};
+        const processedKeys = [];
+
+        for (const prop in objA) {
+            if (prop in objB) {
+                // Merge properties that exist in both objects, or override with property in B
+                if (typeof objA[prop] === "object") nObj[prop] = deepMerge(objA[prop], objB[prop]);
+                else nObj[prop] = objB[prop];
+            } else {
+                // Add properties in A that do not exist in B
+                nObj[prop] = objA[prop];
+            }
+
+            processedKeys.push(prop);
+        }
+
+        // Add properties from B that do not exist in A
+        for (const prop in objB) {
+            if (processedKeys.includes(prop)) continue;
+            nObj[prop] = objB[prop];
+        }
+
+        return nObj;
+    }
+}
+
+module.exports = deepMerge;

--- a/server/views/index.jade
+++ b/server/views/index.jade
@@ -22,6 +22,7 @@ block content
           
           form(id="form" action=`/run` method='POST' style="display:flex; flex-flow:column; height:95%;")
             input(id="code" type="hidden" name="code" value=code)
+            input(type="hidden" name="sessionId" value=sessionId)
             div(id="monaco-editor-container", style="height: 100%; width: 100%")
 
         //right side
@@ -64,6 +65,8 @@ block content
 
           //interaction area
           form.w3-margin-bottom(action=`/run` method='POST' style="flex: 0 1 140px;")
+            input(id="input_code" type="hidden" name="code" value=code)
+            input(type="hidden" name="sessionId" value=sessionId)
             b.w3-text-blue-grey Output:
             .w3-display-container.w3-white(style="height: 60%;")
               input(id="index" name="index" value="3" type="hidden")


### PR DESCRIPTION
Fixed bug related to the instruction `CHECK`, where the second operand would not be recognized, leading to the operation failing with the wrong error, even if well formatted:
```
PUSHI 10
CHECK 0, 20 // Yields the error "Illegal Operand: check - element not between given values"
```

Fixed bug related to the instruction `PUSHA`, where the usage of a non-existing label would lead to a hard crash on the client side, seen below:
![crash example](https://github.com/user-attachments/assets/4227d7a7-3895-4862-95fc-4b73321e2cd4)

**EDIT 2025/04/05:**
Added support for multiple sessions at the same time, fixing a bug where two users submitting a code snippet for interpretation with `read` instructions simultaneously would create a code collision on the global state, leading to one of the users to receive the code from the other user upon an input request.