### PR TITLE
[Fix] DUP integer_n | DUPN

### DIFF
--- a/server/public/javascripts/vm.js
+++ b/server/public/javascripts/vm.js
@@ -455,18 +455,12 @@ module.exports = {
               break
 
             case 44: //dupn
-              if (operand_stack.length >= frame_pointer + 1){
-                var n = operand_stack.pop()
-                if (operand_stack.length >= frame_pointer + n){
-                  var values = []
+              if (operand_stack.length >= frame_pointer + 2){
+                const n = operand_stack.pop()
+                const v = operand_stack.pop()
                   for (let i=0; i < n; i++){
-                    var v = operand_stack.pop()
-                    values.push(v)
                     operand_stack.push(v)
                   }
-                  for (const v of values)
-                    operand_stack.push(v)
-                } else error = 'Segmentation Fault: dupn - elements missing'
               } else error = 'Segmentation Fault: dupn - elements missing'
               break
             case 45: //popn
@@ -529,15 +523,11 @@ module.exports = {
               break
 
             case 52: //dup
-              var values = []
               if (operand_stack.length >= frame_pointer + 1){
+                const v = operand_stack.pop();
                 for (let i=0; i < c[2]; i++){
-                  var v = operand_stack.pop()
-                  values.push(v)
                   operand_stack.push(v)
                 }
-                for (const v of values)
-                  operand_stack.push(v)
               } else error = 'Segmentation Fault: dup - elements missing'
               break
             case 53: //pop

--- a/server/public/javascripts/vm.js
+++ b/server/public/javascripts/vm.js
@@ -530,7 +530,7 @@ module.exports = {
 
             case 52: //dup
               var values = []
-              if (operand_stack.length >= frame_pointer + c[2]){
+              if (operand_stack.length >= frame_pointer + 1){
                 for (let i=0; i < c[2]; i++){
                   var v = operand_stack.pop()
                   values.push(v)


### PR DESCRIPTION
Resumo:
- "Pequeno problema" tratado com a instrução **DUP integer_n**
- Trabalho feito sobre a Stack mais eficiente (no que vem a esta função)
 
 
*(Tudo o que se segue pode ser também aplicado à instrução **DUPN**)*
 
 
De momento, quando a instrução **DUP integer_n** é invocada, a EWVM em vez de verificar a existência de **pelo menos 1 elemento** na Stack, esta verifica a existência de pelo menos **integer_n** elementos na Stack. 

Isto faz com que seja impossível, para uma Stack com só 1 elemento, se execute a instrução **DUP 10**, pois a EWVM verifica que a Stack não tem **pelo menos 10 elementos** em vez de verificar que esta tem **(pelo menos) 1 elemento presente**


<p float="left">
  <img src="https://github.com/user-attachments/assets/6716ebbd-a63a-4f6a-898e-7f5c52afb2ff" width="400" />
  <img src="https://github.com/user-attachments/assets/9af9fcc2-8689-4cd4-8c9a-00b24536c56e" width="400" />
</p>


Para além disso, caso fosse possível executar esta instrução, a maneira como o programa retirava e adicionava o mesmo elemento da Stack consecutivamente, para conseguir adicioná-lo **integer_n** vezes à mesma é extremamente inefeciente.
Caso fosse desejado duplicar o valor no topo da Stack 200x, o programa iria:

<p float="center">
  <img src="https://github.com/user-attachments/assets/ab2012d8-8539-4fec-ba90-7826ad4a0b25" width="200" />
</p>

1. Retirar da Stack o valor que estivesse no topo;
2. Adicionar este valor a uma lista de valores, inicialmente vazia;
3. Voltar a adicioná-lo à Stack original;
4. Repetir 199 vezes.